### PR TITLE
fix: use correct id in `set_source_contents`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1171,9 +1171,10 @@ pub fn adjust_mappings_from_multiple(
             let src = this.get_source(src_id).cloned();
             (
                 src.map(|src| {
-                    let src_id = new_map.add_source(src);
-                    new_map.set_source_contents(src_id, this.get_source_contents(src_id).cloned());
-                    src_id
+                    let new_src_id = new_map.add_source(src);
+                    new_map
+                        .set_source_contents(new_src_id, this.get_source_contents(src_id).cloned());
+                    new_src_id
                 }),
                 this.get_name(name_id).cloned(),
             )
@@ -1182,9 +1183,10 @@ pub fn adjust_mappings_from_multiple(
             let src = this.get_source(src_id).cloned();
             (
                 src.map(|src| {
-                    let src_id = new_map.add_source(src);
-                    new_map.set_source_contents(src_id, this.get_source_contents(src_id).cloned());
-                    src_id
+                    let new_src_id = new_map.add_source(src);
+                    new_map
+                        .set_source_contents(new_src_id, this.get_source_contents(src_id).cloned());
+                    new_src_id
                 }),
                 this.get_name(name_id).cloned(),
             )


### PR DESCRIPTION
Caused invalid source content:
<img width="2018" height="721" alt="image" src="https://github.com/user-attachments/assets/dca54abd-fec5-4f4e-88ac-67e2d255dbfd" />
